### PR TITLE
Updated sax version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
     },
     "devDependencies": {
-        "sax": "0.5.4",
+        "sax": "1.1.1",
         "pegjs": "0.7.0",
         "mocha": "2.1.0",
         "jscover": "0.2.4",


### PR DESCRIPTION
The latest version of sax fixes a bug with the BOM, if you have an XML with BOM at the start old version of sax lib fails with error: Error: Non-whitespace before first tag.
They fixed this https://github.com/isaacs/sax-js/pull/147
I tried saxpath with sax 1.1.1 and it works fine, hope you can add it to the official repo.